### PR TITLE
Prevent infinite loop in puglProcessEvents() (OSX)

### DIFF
--- a/pugl/pugl_osx.m
+++ b/pugl/pugl_osx.m
@@ -686,17 +686,13 @@ puglWaitForEvent(PuglView* view)
 PuglStatus
 puglProcessEvents(PuglView* view)
 {
-	while (true) {
-		// Get the next event, or use the cached one from puglWaitForEvent
-		if (!view->impl->nextEvent) {
-			view->impl->nextEvent = [view->impl->window
-			                            nextEventMatchingMask: NSAnyEventMask];
-		}
+	// Get the next event, or use the cached one from puglWaitForEvent
+	if (!view->impl->nextEvent) {
+		view->impl->nextEvent = [view->impl->window
+		                            nextEventMatchingMask: NSAnyEventMask];
+	}
 
-		if (!view->impl->nextEvent) {
-			break;  // No events to process, done
-		}
-
+	if (view->impl->nextEvent != NULL) {
 		// Dispatch event
 		[view->impl->app sendEvent: view->impl->nextEvent];
 		view->impl->nextEvent = NULL;


### PR DESCRIPTION
(Prerequisite to use keyboard input on OSX is to embed the program to an App bundle.)

Problem:
Using the example program pugl_test, 'q' can not quit the program.
Hitting (X) on the window closes the window but the process is still running and
has to be killed manually.

To track this down, the following "logging" was introduced to pugl_test.c:
(not part of this patch!):

//main loop
while (quit==0) {
fprintf(file,".");fflush(file);
	puglWaitForEvent(view);
fprintf(file,"-");fflush(file);
	puglProcessEvents(view);
fprintf(file,"*");fflush(file);
}

It showed that the loop never turns, and quit can never be evaluated, also
the view will not be destroyed.

It seemed that puglProcessEvents() is blocking.

Removing the while(true) in puglProcessEvents() shows expected behaviour.
Logs show that now the while(quit==0) loop turns and gets all events when
the application has focus. It makes it possible to cleanly quit the program.